### PR TITLE
REP-355: Scale apps post-deploy

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -79,6 +79,17 @@ jobs:
       path: build/((register-name))
       current_app_name: ((register-name))-app
 
+  - task: scale-app
+    config:
+      <<: *cf-task
+      run:
+        path: sh
+        args:
+        - -euc
+        - |
+          cf login -a "${API}" -u "${USERNAME}" -p "${PASSWORD}" -o "${ORGANIZATION}" -s "${SPACE}"
+          cf scale ((register-name))-app -f -m 64M
+
 - name: deploy-route-service
   plan:
   - get: route-service-git


### PR DESCRIPTION
Since we're deploying so many apps on a PaaS plan of 10GB, we need to
limit the amount of memory allocated to each app.

The app manifest currently gets generated by the registers-cli which
makes it a bit messy to alter any resource allocation prior to
deploying. Instead this adds a task which we can use to make any changes
to the app right after deploying.