### PR TITLE
REP-371: Add env var for subdomain suffix

### DIFF
--- a/deploy.yaml
+++ b/deploy.yaml
@@ -157,13 +157,15 @@ jobs:
         - name: registers
       outputs:
         - name: registers
+      params:
+        SUBDOMAIN_SUFFIX: -reg
       run:
         path: sh
         args:
           - -uec
           - |
             pipelines/generate_manifest.rb registers/registers.txt registers/manifest.yml
-            cp pipelines/nginx.conf registers/nginx.conf
+            erb pipelines/nginx.conf.erb > registers/nginx.conf
   - put: paas-app
     params:
       current_app_name: registers

--- a/nginx.conf.erb
+++ b/nginx.conf.erb
@@ -28,7 +28,7 @@ http {
   }
 
   map $host $register_name {
-    ~^(?<reg>.+)-reg\..+$ $reg;
+    ~^(?<reg>.+)<%= ENV.fetch('SUBDOMAIN_SUFFIX', '') %>\..+$ $reg;
   }
 
   lua_package_path "$prefix/lua/?.lua;/home/vcap/deps/0/nginx/lualib/?.lua;/usr/local/openresty/nginx/lua/?.lua;;";


### PR DESCRIPTION
On PaaS all the registers are served at
`<register>-reg.london.cloudapps.digital` but when we start serving them
off a regular URL, the subdomain will no longer contain the `-reg`. This
change allows for an optional suffix provided by the `SUBDOMAIN_SUFFIX`
environment variable.